### PR TITLE
Fatma || Feature/display special days

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Node.js
+node_modules/
+npm-debug.log
+.env
+
+# OS-specific
+.DS_Store
+Thumbs.db
+
+# IDEs
+.vscode/
+.idea/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="A useful and interactive calendar that displays commemorative days dynamically based on JSON data. Navigate through months and years easily.">
+  <title>Days Calendar</title>
+</head>
+
+<body>
+  <h1>Calendar</h1>
+  <p>This is the homepage.</p>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -7,11 +7,43 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="A useful and interactive calendar that displays commemorative days dynamically based on JSON data. Navigate through months and years easily.">
   <title>Days Calendar</title>
+  <link rel="stylesheet" href="style.css"> 
 </head>
 
 <body>
-  <h1>Calendar</h1>
-  <p>This is the homepage.</p>
+  <h1 class="page-title">Days Calendar</h1>
+  <main class="calendar-container">
+    <!-- Section for jumping to a specific date -->
+    <div class="jump-to-date-controls">
+      <select id="month-select" aria-label="Select Month"></select>
+      <select id="year-select" aria-label="Select Year"></select>
+      <button id="go-btn">Go</button>
+    </div>
+
+    <!-- Section for navigating between months -->
+    <div class="month-navigation-controls">
+      <button id="prev-month-btn" aria-label="Previous Month">Previous Month</button>
+      <button id="next-month-btn" aria-label="Next Month">Next Month</button>
+    </div>
+
+    <!-- Weekday headers -->
+    <div class="calendar-weekdays">
+      <div>Mon</div>
+      <div>Tue</div>
+      <div>Wed</div>
+      <div>Thu</div>
+      <div>Fri</div>
+      <div>Sat</div>
+      <div>Sun</div>
+    </div>
+    
+    <!-- The grid for the days -->
+    <div id="calendar-grid" class="calendar-grid">
+      <!-- This area will be populated by JavaScript -->
+    </div>
+  </main>
+
+  <script type="module" src="src/main.js"></script>
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "project-days-calendar",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Fradoka/Project-Days-Calendar.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "bugs": {
+    "url": "https://github.com/Fradoka/Project-Days-Calendar/issues"
+  },
+  "homepage": "https://github.com/Fradoka/Project-Days-Calendar#readme"
+}

--- a/src/date-logic.js
+++ b/src/date-logic.js
@@ -1,0 +1,63 @@
+// Helper to convert ordinal string to a number
+function ordinalToNumber(ordinal) {
+  const map = {
+    first: 1,
+    second: 2,
+    third: 3,
+    fourth: 4,
+    fifth: 5,
+    last: -1
+  };
+  return map[ordinal.toLowerCase()];
+}
+
+export function calculateDateForRule(rule, year, month) {
+  const ordinal = ordinalToNumber(rule.ordinal);
+  const dayName = rule.day.toLowerCase();
+
+  // Map day names to day numbers (Sunday=0, Monday=1, ..., Saturday=6)
+  const daysMap = {
+    sunday: 0,
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6
+  };
+
+  const targetDay = daysMap[dayName];
+  if (targetDay === undefined || !year || month === undefined) {
+    throw new Error('Invalid input');
+  }
+
+  // If ordinal is "last", find last occurrence of that day in the month
+  if (ordinal === -1) {
+    // Find last day of the month
+    const lastDate = new Date(year, month + 1, 0);
+    // Go backward from the last day to find the target day
+    const lastDayOfWeek = lastDate.getDay();
+    let diff = lastDayOfWeek - targetDay;
+    if (diff < 0) diff += 7;
+    return new Date(year, month, lastDate.getDate() - diff);
+  }
+
+  // Otherwise, find the first occurrence of the target day in the month
+  // Then add (ordinal - 1) weeks to it
+  const firstOfMonth = new Date(year, month, 1);
+  const firstDayOfWeek = firstOfMonth.getDay();
+
+  let dayOffset = targetDay - firstDayOfWeek;
+  if (dayOffset < 0) dayOffset += 7;
+
+  // Calculate the date of the nth occurrence of the target day
+  const date = 1 + dayOffset + 7 * (ordinal - 1);
+
+  // Check if date is valid within month
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  if (date > daysInMonth) {
+    throw new Error('The specified ordinal day does not exist in this month');
+  }
+
+  return new Date(year, month, date);
+}

--- a/src/days.json
+++ b/src/days.json
@@ -1,0 +1,37 @@
+[
+    {
+        "name": "Ada Lovelace Day",
+        "monthName": "October",
+        "dayName": "Tuesday",
+        "occurence": "second",
+        "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/ada.txt"
+    },
+    {
+        "name": "International Binturong Day",
+        "monthName": "May",
+        "dayName": "Saturday",
+        "occurence": "second",
+        "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/binturongs.txt"
+    },
+    {
+        "name": "International Vulture Awareness Day",
+        "monthName": "September",
+        "dayName": "Saturday",
+        "occurence": "first",
+        "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/vultures.txt"
+    },
+    {
+        "name": "International Red Panda Day",
+        "monthName": "September",
+        "dayName": "Saturday",
+        "occurence": "third",
+        "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/red-pandas.txt"
+    },
+    {
+        "name": "World Lemur Day",
+        "monthName": "October",
+        "dayName": "Friday",
+        "occurence": "last",
+        "descriptionURL": "https://codeyourfuture.github.io/The-Piscine/days/lemurs.txt"
+    }
+]

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,100 @@
+// DOM elements
+const prevMonthBtn = document.getElementById('prev-month-btn');
+const nextMonthBtn = document.getElementById('next-month-btn');
+const monthSelect = document.getElementById('month-select');
+const yearSelect = document.getElementById('year-select');
+const goBtn = document.getElementById('go-btn');
+const calendarGrid = document.getElementById('calendar-grid');
+
+let currentDate = new Date();
+const monthNames = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"
+];
+
+// Renders the calendar for a given month and year
+function renderCalendar(year, month) {
+  calendarGrid.innerHTML = '';
+  
+  // Update the dropdowns to show the current date
+  monthSelect.value = month;
+  yearSelect.value = year;
+
+  // Get date information for the current month
+  const firstDayOfMonth = new Date(year, month, 1);
+  const lastDayOfMonth = new Date(year, month + 1, 0);
+
+  // Adjust so Monday is the first day of the week (1) and Sunday is the last (7)
+  let firstDayOfWeek = firstDayOfMonth.getDay();
+  if (firstDayOfWeek === 0) {
+    firstDayOfWeek = 7;
+  }
+  
+  // Draw days from the previous month
+  const daysFromPrevMonth = firstDayOfWeek - 1;
+  for (let i = 0; i < daysFromPrevMonth; i++) {
+    const dayElement = document.createElement('div');
+    dayElement.classList.add('other-month');
+    const day = new Date(year, month, 0).getDate() - daysFromPrevMonth + i + 1;
+    dayElement.textContent = day;
+    calendarGrid.appendChild(dayElement);
+  }
+
+  // Draw days for the current month
+  for (let i = 1; i <= lastDayOfMonth.getDate(); i++) {
+    const dayElement = document.createElement('div');
+    dayElement.textContent = i;
+    calendarGrid.appendChild(dayElement);
+  }
+
+  // Draw days from the next month
+  const totalCells = daysFromPrevMonth + lastDayOfMonth.getDate();
+  const daysFromNextMonth = (totalCells % 7 === 0) ? 0 : 7 - (totalCells % 7);
+  for (let i = 1; i <= daysFromNextMonth; i++) {
+    const dayElement = document.createElement('div');
+    dayElement.classList.add('other-month');
+    dayElement.textContent = i;
+    calendarGrid.appendChild(dayElement);
+  }
+}
+
+// Fills the dropdowns with month and year options
+function populateSelectors() {
+  monthNames.forEach((name, index) => {
+    const option = document.createElement('option');
+    option.value = index;
+    option.textContent = name;
+    monthSelect.appendChild(option);
+  });
+
+  for (let year = 1900; year <= 2100; year++) {
+    const option = document.createElement('option');
+    option.value = year;
+    option.textContent = year;
+    yearSelect.appendChild(option);
+  }
+}
+
+prevMonthBtn.addEventListener('click', () => {
+  currentDate.setMonth(currentDate.getMonth() - 1);
+  renderCalendar(currentDate.getFullYear(), currentDate.getMonth());
+});
+
+nextMonthBtn.addEventListener('click', () => {
+  currentDate.setMonth(currentDate.getMonth() + 1);
+  renderCalendar(currentDate.getFullYear(), currentDate.getMonth());
+});
+
+goBtn.addEventListener('click', () => {
+  const selectedYear = parseInt(yearSelect.value, 10);
+  const selectedMonth = parseInt(monthSelect.value, 10);
+  currentDate = new Date(selectedYear, selectedMonth, 1);
+  renderCalendar(currentDate.getFullYear(), currentDate.getMonth());
+});
+
+function init() {
+  populateSelectors();
+  renderCalendar(currentDate.getFullYear(), currentDate.getMonth());
+}
+
+init();

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,5 @@
+import { getSpecialDaysForMonth } from './special-days.js';
+
 // DOM elements
 const prevMonthBtn = document.getElementById('prev-month-btn');
 const nextMonthBtn = document.getElementById('next-month-btn');
@@ -13,12 +15,15 @@ const monthNames = [
 ];
 
 // Renders the calendar for a given month and year
-function renderCalendar(year, month) {
+async function renderCalendar(year, month) {
   calendarGrid.innerHTML = '';
   
   // Update the dropdowns to show the current date
   monthSelect.value = month;
   yearSelect.value = year;
+
+  // Get the list of special days for the current month
+  const specialDays = await getSpecialDaysForMonth(year, month);
 
   // Get date information for the current month
   const firstDayOfMonth = new Date(year, month, 1);
@@ -43,7 +48,15 @@ function renderCalendar(year, month) {
   // Draw days for the current month
   for (let i = 1; i <= lastDayOfMonth.getDate(); i++) {
     const dayElement = document.createElement('div');
+
     dayElement.textContent = i;
+
+    // Check if the current day 'i' is a special day
+    const specialDay = specialDays.find(day => day.date.getDate() === i);
+    if (specialDay) {
+      dayElement.classList.add('special-day');
+    }
+
     calendarGrid.appendChild(dayElement);
   }
 

--- a/src/special-days.js
+++ b/src/special-days.js
@@ -1,0 +1,30 @@
+import days from './days.json'; 
+import { calculateDateForRule } from './date-logic.js';
+
+export function getSpecialDaysForMonth(year, month) {
+  // Get month name (e.g., 'October') from number
+  const monthNames = [
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+  ];
+  const monthName = monthNames[month];
+
+  // Filter commemorative days for this month
+  const daysForMonth = days.filter(day => day.monthName === monthName);
+
+  // Map each day to an object with calculated date
+  return daysForMonth.map(day => {
+    const rule = {
+      ordinal: day.occurence,
+      day: day.dayName
+    };
+
+    const date = calculateDateForRule(rule, year, month);
+
+    return {
+      name: day.name,
+      date,
+      descriptionURL: day.descriptionURL
+    };
+  });
+}

--- a/src/special-days.js
+++ b/src/special-days.js
@@ -1,7 +1,10 @@
-import days from './days.json'; 
 import { calculateDateForRule } from './date-logic.js';
 
-export function getSpecialDaysForMonth(year, month) {
+export async function getSpecialDaysForMonth(year, month) {
+  // Fetch the JSON data
+  const response = await fetch('./src/days.json');
+  const days = await response.json(); // Parse the response as JSON
+
   // Get month name (e.g., 'October') from number
   const monthNames = [
     "January", "February", "March", "April", "May", "June",

--- a/style.css
+++ b/style.css
@@ -124,3 +124,10 @@ body {
   background-color: #fafafa;
   cursor: default;
 }
+
+.special-day {
+  background-color: #e6f7ff;
+  border-color: #91d5ff;
+  font-weight: bold;
+  color: #0056b3;
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,126 @@
+/* General Body and Font Styling */
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f0f2f5;
+  
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  margin: 0;
+  
+  /* Reduced the gap between the title and the calendar */
+  gap: 1.5rem; 
+}
+
+/* Page Title Styling */
+.page-title {
+  /* Slightly smaller font size for the main title */
+  font-size: 2.25rem;
+  font-weight: 600;
+  color: #333;
+  margin: 0;
+}
+
+/* The main white container for the calendar */
+.calendar-container {
+  background-color: white;
+  
+  /* Reduced the padding inside the container */
+  padding: 1.5rem; 
+  
+  border-radius: 15px;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.1);
+  width: 90%;
+  
+  /* Reduced the max-width to make the calendar more compact */
+  max-width: 450px; 
+}
+
+/* Container for Jump to Date controls */
+.jump-to-date-controls {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem; /* Reduced gap between controls */
+  margin-bottom: 1rem;
+}
+
+/* Container for Month Navigation */
+.month-navigation-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+/* Common styling for all buttons and selects */
+.jump-to-date-controls select,
+.jump-to-date-controls button,
+.month-navigation-controls button {
+  /* Smaller padding and font size for a more compact look */
+  padding: 0.5rem 0.8rem;
+  font-size: 0.9rem;
+  
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  background-color: #fff;
+  cursor: pointer;
+  transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.jump-to-date-controls button,
+.month-navigation-controls button:hover {
+  background-color: #f9f9f9;
+}
+
+/* Weekday headers (Mon, Tue, etc.) */
+.calendar-weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 0.5rem;
+  color: #555;
+  font-size: 0.85rem; /* Slightly smaller font for weekdays */
+}
+
+/* The main grid for the days */
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  
+  /* Reduced the gap between day boxes */
+  gap: 8px; 
+}
+
+/* Individual day boxes */
+.calendar-grid div {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  aspect-ratio: 1 / 1; 
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  
+  /* Slightly smaller font size for the numbers */
+  font-size: 0.9rem;
+  
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+}
+
+/* Hover effect for days in the current month */
+.calendar-grid div:not(.other-month):hover {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+/* Styling for days that are not in the current month */
+.calendar-grid .other-month {
+  color: #545454;
+  background-color: #fafafa;
+  cursor: default;
+}


### PR DESCRIPTION
Hi @Fradoka and @Mgphone,

This PR completes **Ticket 6** by integrating the special days logic with the calendar UI.

**Changes:**

*   The `renderCalendar` function now fetches the special days for the current month using `getSpecialDaysForMonth`.
*   Days that are identified as special are marked with a `.special-day` CSS class.
*   A new style has been added to give these special days a distinct background color, indicating to the user that they are interactive.

Instead of displaying the event name directly in the small cell, we are using this color highlight as a visual cue. This keeps the UI clean and prepares for the next ticket, where users will click these days to see the full description.

Ready for review. Thanks!