### PR TITLE
Fatma || Feature/display description modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,15 @@
     </div>
   </main>
 
+  <!-- The Modal (hidden by default) -->
+  <div id="description-modal" class="modal-overlay hidden">
+    <div class="modal-content">
+      <button id="close-modal-btn" class="close-btn" aria-label="Close">×</button>
+      <h2 id="modal-title"></h2>
+      <p id="modal-description"></p>
+    </div>
+  </div>
+
   <script type="module" src="src/main.js"></script>
 </body>
 

--- a/style.css
+++ b/style.css
@@ -130,4 +130,76 @@ body {
   border-color: #91d5ff;
   font-weight: bold;
   color: #0056b3;
+  position: relative;
+}
+
+/* The actual tooltip bubble (hidden by default) */
+.special-day .tooltip {
+  visibility: hidden; 
+  opacity: 0; /* Make it transparent */
+  
+  width: max-content; /* Make the width fit the content */
+  max-width: 150px;
+  background-color: #333;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 10px;
+  
+  /* Position the tooltip above the day box */
+  position: absolute;
+  z-index: 1;
+  bottom: 110%; /* Place it just above the box */
+  left: 50%;
+  transform: translateX(-50%); /* Center it horizontally */
+
+  transition: opacity 0.2s;
+}
+
+/* Show the tooltip when hovering over a special day */
+.special-day:hover .tooltip {
+  visibility: visible;
+  opacity: 1;
+}
+
+.modal-overlay {
+  position: fixed; /* Stays in place even if you scroll */
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6); /* Semi-transparent black background */
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Ensures it's on top of everything */
+}
+
+.modal-content {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 10px;
+  width: 90%;
+  max-width: 500px;
+  position: relative;
+}
+
+.close-btn {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 1.5rem;
+  font-weight: bold;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+#modal-title {
+  margin-top: 0;
+}
+
+/* A helper class to hide the modal */
+.hidden {
+  display: none;
 }


### PR DESCRIPTION
Hi @Mgphone and @Fradoka,

**I implemented:**

1.  **Click to View Description:** When a user clicks on a special day (highlighted in blue), a modal window opens.
2.  **API Integration:** The modal fetches and displays the detailed description for that day by calling the `fetchDescription` function from our `api.js` module. A "Loading..." state is shown while the data is being fetched.
3.  **Modal Functionality:** The modal is fully interactive and can be closed in three ways:
    *   Clicking the 'X' button.
    *   Clicking on the dark background overlay.
    *   Pressing the 'Escape' key.
4.  **Hover Tooltip (UX Improvement):** For better usability, hovering over a special day now shows a tooltip with the event's full name.

This implementation uses **event delegation** for efficient click handling, which improves performance by adding only a single event listener to the calendar grid.

With this, all the frontend requirements should be complete. Please review the changes.

Thanks!